### PR TITLE
Remove pytest-asyncio

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,5 @@ aiohttp
 beautifulsoup4
 cryptography
 lxml
-pytest-asyncio
 pyjwt
 xmltodict


### PR DESCRIPTION
`pytest-asyncio` is not a runtime requirement. It's used for testing. 