### PR TITLE
Remove pytest

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,5 @@ setuptools.setup(
     use_scm_version={"local_scheme": local_scheme},
     setup_requires=[
         'setuptools_scm',
-        'pytest>=5,<6',
     ]
 )


### PR DESCRIPTION
`pytest` is a test requirement and not a requirement for the setup.